### PR TITLE
Removes ES6 functionality to support IE11

### DIFF
--- a/px-api-viewer.html
+++ b/px-api-viewer.html
@@ -325,7 +325,7 @@ Custom property | Description
         this._targetElementDescriptor = {};
       }
 
-      let d;
+      var d;
       if (! (name === undefined || descriptor === undefined)) {
         d = descriptor.elements.filter(function(el) {
           return el.name === name || el.tagname === name;


### PR DESCRIPTION
No changes to actual functionality, only removes ES6 notations like const, let, =>, ..., in order to support IE11.